### PR TITLE
Adds .gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,49 @@
+image: golang:1.8-alpine
+
+variables:
+  DOCKER_DRIVER: overlay
+  PKG_PATH: github.com/jetstack-experimental/cert-manager
+
+services:
+- docker:1.12-dind
+
+before_script:
+  - apk --update add make docker bash curl
+  - export DOCKER_HOST=${DOCKER_PORT}
+  - docker info > /dev/null
+  - mkdir -p "${GOPATH}/src/${PKG_PATH}" && rmdir "${GOPATH}/src/${PKG_PATH}"
+  - mv "${CI_PROJECT_DIR}" "${GOPATH}/src/${PKG_PATH}"
+  - cd "${GOPATH}/src/${PKG_PATH}"
+  - mkdir -p "${CI_PROJECT_DIR}"
+
+after_script:
+  - cd "/"
+  - rm -rf "${CI_PROJECT_DIR}"
+  - mv "${GOPATH}/src/${PKG_PATH}" "${CI_PROJECT_DIR}"
+
+build:
+  tags:
+  - docker
+  script:
+  - make all image
+  except:
+  - master
+  - tags
+
+master_push:
+  tags:
+  - docker
+  script:
+  - mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json
+  - make all push IMAGE_TAGS="${CI_BUILD_REF_SLUG}-${CI_PIPELINE_ID} canary"
+  only:
+  - master
+
+release_push:
+  tags:
+  - docker
+  script:
+  - mkdir -p ~/.docker && echo "${DOCKER_AUTH_CONFIG}" > ~/.docker/config.json && chmod 600 ~/.docker/config.json
+  - make all push APP_VERSION=${CI_COMMIT_TAG} IMAGE_TAGS="${CI_COMMIT_TAG} latest"
+  only:
+  - tags

--- a/Dockerfile.acmesolver
+++ b/Dockerfile.acmesolver
@@ -5,3 +5,7 @@ RUN apk add --no-cache ca-certificates
 ADD _build/cert-manager-acmesolver-linux-amd64 /usr/bin/acmesolver
 
 ENTRYPOINT ["/usr/bin/acmesolver"]
+ARG VCS_REF
+LABEL org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/jetstack-experimental/cert-manager" \
+      org.label-schema.license="Apache-2.0"

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -5,3 +5,7 @@ RUN apk add --no-cache ca-certificates
 ADD _build/cert-manager-controller-linux-amd64 /usr/bin/cert-manager
 
 ENTRYPOINT ["/usr/bin/cert-manager"]
+ARG VCS_REF
+LABEL org.label-schema.vcs-ref=$VCS_REF \
+      org.label-schema.vcs-url="https://github.com/jetstack-experimental/cert-manager" \
+      org.label-schema.license="Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-ACCOUNT=jetstack-experimental
+ACCOUNT=jetstackexperimental
 APP_NAME=cert-manager
-REGISTRY=quay.io
+REGISTRY=docker.io
 
 PACKAGE_NAME=github.com/${ACCOUNT}/${APP_NAME}
 GO_VERSION=1.8
@@ -54,6 +54,10 @@ depend:
 
 verify: .hack_verify
 test: go_test
+
+version:
+	$(eval GIT_STATE := $(shell if test -z "`git status --porcelain 2> /dev/null`"; then echo "clean"; else echo "dirty"; fi))
+	$(eval GIT_COMMIT := $(shell git rev-parse HEAD))
 
 build_%: depend version
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \


### PR DESCRIPTION
@munnerz I still went with one stage for gitlab, I think it's easier for now (the golang binaries are quite big in size and I rather not having them stored on the gitlab server for every build)

The master will always assing a unique one and update the `canary` tag

Git tags translate into docker image tags and will update the latest reference