### PR TITLE
Use shorter names for http solver resources

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -40,16 +40,16 @@ const (
 
 // svcNameFunc returns the name for the service to solve the challenge
 func svcNameFunc(crtName, domain string) string {
-	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, domain))
+	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, util.RandStringRunes(5)))
 }
 
 // ingNameFunc returns the name for the ingress to solve the challenge
 func ingNameFunc(crtName, domain string) string {
-	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, domain))
+	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, util.RandStringRunes(5)))
 }
 
 func jobNameFunc(crtName, domain string) string {
-	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, domain))
+	return dns1035(fmt.Sprintf("cm-%s-%s", crtName, util.RandStringRunes(5)))
 }
 
 // Solver is an implementation of the acme http-01 challenge solver protocol


### PR DESCRIPTION
This is a quick workaround for #92 

Really, crtName could be up to 63 characters, so we need to make sure to truncate it in order to guarantee the length of the resource is then <63 chars.