### PR TITLE
Move to github.com/jetstack/cert-manager repo

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ image: golang:1.8-alpine
 
 variables:
   DOCKER_DRIVER: overlay
-  PKG_PATH: github.com/jetstack-experimental/cert-manager
+  PKG_PATH: github.com/jetstack/cert-manager
 
 services:
 - docker:1.12-dind

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-go_import_path: github.com/jetstack-experimental/cert-manager
+go_import_path: github.com/jetstack/cert-manager
 
 jobs:
   include:

--- a/Dockerfile.acmesolver
+++ b/Dockerfile.acmesolver
@@ -7,5 +7,5 @@ ADD _build/cert-manager-acmesolver-linux-amd64 /usr/bin/acmesolver
 ENTRYPOINT ["/usr/bin/acmesolver"]
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/jetstack-experimental/cert-manager" \
+      org.label-schema.vcs-url="https://github.com/jetstack/cert-manager" \
       org.label-schema.license="Apache-2.0"

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -7,5 +7,5 @@ ADD _build/cert-manager-controller-linux-amd64 /usr/bin/cert-manager
 ENTRYPOINT ["/usr/bin/cert-manager"]
 ARG VCS_REF
 LABEL org.label-schema.vcs-ref=$VCS_REF \
-      org.label-schema.vcs-url="https://github.com/jetstack-experimental/cert-manager" \
+      org.label-schema.vcs-url="https://github.com/jetstack/cert-manager" \
       org.label-schema.license="Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-ACCOUNT=jetstackexperimental
+ACCOUNT=jetstack
 APP_NAME=cert-manager
-REGISTRY=docker.io
+REGISTRY=quay.io
 
-PACKAGE_NAME=github.com/jetstack-experimental/cert-manager
+PACKAGE_NAME=github.com/jetstack/cert-manager
 GO_VERSION=1.8
 
 GOOS := linux
@@ -60,7 +60,7 @@ build_%: depend version
 	CGO_ENABLED=0 GOOS=$(GOOS) GOARCH=$(GOARCH) go build \
 		-a -tags netgo \
 		-o ${BUILD_DIR}/${APP_NAME}-$*-$(GOOS)-$(GOARCH) \
-		-ldflags "-X github.com/jetstack-experimental/cert-manager/pkg/util.AppGitState=${GIT_STATE} -X github.com/jetstack-experimental/cert-manager/pkg/util.AppGitCommit=${GIT_COMMIT} -X github.com/jetstack-experimental/cert-manager/pkg/util.AppVersion=${APP_VERSION}" \
+		-ldflags "-X github.com/jetstack/cert-manager/pkg/util.AppGitState=${GIT_STATE} -X github.com/jetstack/cert-manager/pkg/util.AppGitCommit=${GIT_COMMIT} -X github.com/jetstack/cert-manager/pkg/util.AppVersion=${APP_VERSION}" \
 		./cmd/$*
 
 go_fmt:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# cert-manager [![Build Status](https://travis-ci.org/jetstack-experimental/cert-manager.svg?branch=master)](https://travis-ci.org/jetstack-experimental/cert-manager)
+# cert-manager [![Build Status](https://travis-ci.org/jetstack/cert-manager.svg?branch=master)](https://travis-ci.org/jetstack/cert-manager)
 
 cert-manager is a Kubernetes add-on to automate the management and issuance of
 TLS certificates from various issuing sources.
@@ -61,7 +61,7 @@ repository.
 ## Troubleshooting
 
 If you encounter any issues whilst using cert-manager, and your issue is not
-documented, please [file an issue](https://github.com/jetstack-experimental/cert-manager/issues).
+documented, please [file an issue](https://github.com/jetstack/cert-manager/issues).
 
 ## Contributing
 
@@ -69,7 +69,7 @@ We welcome pull requests with open arms! There's a lot of work to do here, and
 we're especially concerned with ensuring the longevity and reliability of the
 project.
 
-Please take a look at our [issue tracker](https://github.com/jetstack-experimental/cert-manager/issues)
+Please take a look at our [issue tracker](https://github.com/jetstack/cert-manager/issues)
 if you are unsure where to start with getting involved!
 
 We also use the #kube-lego channel on kubernetes.slack.com for chat relating to
@@ -79,5 +79,5 @@ Developer documentation should be available soon at [docs/devel](docs/devel).
 
 ## Changelog
 
-The [list of releases](https://github.com/jetstack-experimental/cert-manager/releases)
+The [list of releases](https://github.com/jetstack/cert-manager/releases)
 is the best place to look for information on changes between releases.

--- a/cmd/acmesolver/main.go
+++ b/cmd/acmesolver/main.go
@@ -4,7 +4,7 @@ import (
 	"flag"
 	"log"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/http/solver"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
 )
 
 // acmesolver solves ACME http-01 challenges. This is intended to run as a pod

--- a/cmd/controller/app/controller.go
+++ b/cmd/controller/app/controller.go
@@ -18,14 +18,14 @@ import (
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/jetstack-experimental/cert-manager/cmd/controller/app/options"
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	intscheme "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/scheme"
-	informers "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions"
-	"github.com/jetstack-experimental/cert-manager/pkg/controller"
-	"github.com/jetstack-experimental/cert-manager/pkg/controller/clusterissuers"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	kubeinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers"
+	"github.com/jetstack/cert-manager/cmd/controller/app/options"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	intscheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
+	informers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+	"github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/controller/clusterissuers"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	kubeinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers"
 )
 
 const controllerAgentName = "cert-manager-controller"

--- a/cmd/controller/app/options/options.go
+++ b/cmd/controller/app/options/options.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/spf13/pflag"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/util"
 )
 
 type ControllerOptions struct {
@@ -36,7 +36,7 @@ const (
 )
 
 var (
-	defaultACMEHTTP01SolverImage = fmt.Sprintf("jetstackexperimental/cert-manager-acmesolver:%s", util.AppVersion)
+	defaultACMEHTTP01SolverImage = fmt.Sprintf("quay.io/jetstack/cert-manager-acmesolver:%s", util.AppVersion)
 )
 
 func NewControllerOptions() *ControllerOptions {

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -21,8 +21,8 @@ import (
 
 	"github.com/golang/glog"
 
-	_ "github.com/jetstack-experimental/cert-manager/pkg/issuer/acme"
-	"github.com/jetstack-experimental/cert-manager/pkg/logs"
+	_ "github.com/jetstack/cert-manager/pkg/issuer/acme"
+	"github.com/jetstack/cert-manager/pkg/logs"
 )
 
 func main() {

--- a/cmd/controller/start.go
+++ b/cmd/controller/start.go
@@ -9,14 +9,14 @@ import (
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/jetstack-experimental/cert-manager/cmd/controller/app"
-	"github.com/jetstack-experimental/cert-manager/cmd/controller/app/options"
-	_ "github.com/jetstack-experimental/cert-manager/pkg/controller/certificates"
-	_ "github.com/jetstack-experimental/cert-manager/pkg/controller/clusterissuers"
-	_ "github.com/jetstack-experimental/cert-manager/pkg/controller/issuers"
-	_ "github.com/jetstack-experimental/cert-manager/pkg/issuer/acme"
-	_ "github.com/jetstack-experimental/cert-manager/pkg/issuer/ca"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/cmd/controller/app"
+	"github.com/jetstack/cert-manager/cmd/controller/app/options"
+	_ "github.com/jetstack/cert-manager/pkg/controller/certificates"
+	_ "github.com/jetstack/cert-manager/pkg/controller/clusterissuers"
+	_ "github.com/jetstack/cert-manager/pkg/controller/issuers"
+	_ "github.com/jetstack/cert-manager/pkg/issuer/acme"
+	_ "github.com/jetstack/cert-manager/pkg/issuer/ca"
+	"github.com/jetstack/cert-manager/pkg/util"
 )
 
 type CertManagerControllerOptions struct {

--- a/contrib/charts/cert-manager/README.md
+++ b/contrib/charts/cert-manager/README.md
@@ -46,7 +46,7 @@ The following tables lists the configurable parameters of the Drupal chart and t
 
 | Parameter              | Description                             | Default                                        |
 | ---------------------- | --------------------------------------- | ---------------------------------------------- |
-| `image.repository`     | Image repository                        | `jetstackexperimental/cert-manager-controller` |
+| `image.repository`     | Image repository                        | `quay.io/jetstack/cert-manager-controller`     |
 | `image.tag`            | Image tag                               | `canary`                                       |
 | `image.pullPolicy`     | Image pull policy                       | `Always`                                       |
 | `replicaCount`         | Number of cert-manager replicas         | `1`                                            |

--- a/contrib/charts/cert-manager/values.yaml
+++ b/contrib/charts/cert-manager/values.yaml
@@ -4,7 +4,7 @@
 replicaCount: 1
 
 image:
-  repository: jetstackexperimental/cert-manager-controller
+  repository: quay.io/jetstack/cert-manager-controller
   tag: v0.1.1
   pullPolicy: Always
 

--- a/docs/examples/cert-manager.yaml
+++ b/docs/examples/cert-manager.yaml
@@ -13,5 +13,5 @@ spec:
     spec:
       containers:
       - name: cert-manager
-        image: jetstackexperimental/cert-manager-controller:canary
+        image: quay.io/jetstack/cert-manager-controller:canary
         imagePullPolicy: Always

--- a/docs/user-guides/helm.md
+++ b/docs/user-guides/helm.md
@@ -6,4 +6,4 @@ To deploy the latest version of cert-manager using Helm, run:
 $ helm install --name cert-manager --namespace kube-system contrib/charts/cert-manager
 ```
 
-By default, it will be configured to fulfil `Certificate` resources in all namespaces. There are a number of options you can customise when deploying, as detailed in [the chart itself](https://github.com/jetstack-experimental/cert-manager/tree/master/contrib/charts/cert-manager).
+By default, it will be configured to fulfil `Certificate` resources in all namespaces. There are a number of options you can customise when deploying, as detailed in [the chart itself](../../contrib/charts/cert-manager).

--- a/hack/cherry-pick-pull.sh
+++ b/hack/cherry-pick-pull.sh
@@ -139,7 +139,7 @@ Cherry pick of ${PULLSUBJ} on ${rel}.
 $(printf '%s\n' "${SUBJECTS[@]}")
 EOF
 
-  hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "jetstack-experimental:${rel}"
+  hub pull-request -F "${prtext}" -h "${GITHUB_USER}:${NEWBRANCH}" -b "jetstack:${rel}"
 }
 
 git checkout -b "${NEWBRANCHUNIQ}" "${BRANCH}"
@@ -148,7 +148,7 @@ cleanbranch="${NEWBRANCHUNIQ}"
 gitamcleanup=true
 for pull in "${PULLS[@]}"; do
   echo "+++ Downloading patch to /tmp/${pull}.patch (in case you need to do this again)"
-  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/jetstack-experimental/cert-manager/pull/${pull}.patch"
+  curl -o "/tmp/${pull}.patch" -sSL "https://github.com/jetstack/cert-manager/pull/${pull}.patch"
   echo
   echo "+++ About to attempt cherry pick of PR. To reattempt:"
   echo "  $ git am -3 /tmp/${pull}.patch"

--- a/hack/update-client-gen.sh
+++ b/hack/update-client-gen.sh
@@ -10,7 +10,7 @@ SCRIPT_ROOT=$(dirname ${BASH_SOURCE})/..
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../code-generator)}
 
 ${CODEGEN_PKG}/generate-groups.sh "deepcopy,defaulter,client,informer,lister" \
-  github.com/jetstack-experimental/cert-manager/pkg/client github.com/jetstack-experimental/cert-manager/pkg/apis \
+  github.com/jetstack/cert-manager/pkg/client github.com/jetstack/cert-manager/pkg/apis \
   certmanager:v1alpha1 \
   --output-base "${GOPATH}/src/" \
   --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt
@@ -21,6 +21,6 @@ ${GOPATH}/bin/informer-gen \
            --input-dirs "k8s.io/api/extensions/v1beta1" \
            --versioned-clientset-package "k8s.io/client-go/kubernetes" \
            --listers-package "k8s.io/client-go/listers" \
-           --output-package "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers" \
+           --output-package "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers" \
            --go-header-file ${SCRIPT_ROOT}/hack/boilerplate.go.txt \
            --single-directory

--- a/labels.yaml
+++ b/labels.yaml
@@ -1,5 +1,5 @@
 ---
-repo: jetstack-experimental/cert-manager
+repo: jetstack/cert-manager
 labels:
 - name: approved
   color: 0ffa16

--- a/pkg/api/register.go
+++ b/pkg/api/register.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/apimachinery/announced"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/install"
+)
+
+var (
+	groupFactoryRegistry = make(announced.APIGroupFactoryRegistry)
+	// Registry is an instance of an API registry.
+	Registry = registered.NewOrDie("")
+	// Scheme for API object types
+	Scheme = runtime.NewScheme()
+	// ParameterCodec handles versioning of objects that are converted to query parameters.
+	ParameterCodec = runtime.NewParameterCodec(Scheme)
+	// Codecs for creating a server config
+	Codecs = serializer.NewCodecFactory(Scheme)
+)
+
+func init() {
+	install.Install(groupFactoryRegistry, Registry, Scheme)
+
+	// we need to add the options to empty v1
+	// TODO fix the server code to avoid this
+	metav1.AddToGroupVersion(Scheme, schema.GroupVersion{Version: "v1"})
+
+	// TODO: keep the generic API server from wanting this
+	unversioned := schema.GroupVersion{Group: "", Version: "v1"}
+	Scheme.AddUnversionedTypes(unversioned,
+		&metav1.Status{},
+		&metav1.APIVersions{},
+		&metav1.APIGroupList{},
+		&metav1.APIGroup{},
+		&metav1.APIResourceList{},
+	)
+}

--- a/pkg/apis/certmanager/install/install.go
+++ b/pkg/apis/certmanager/install/install.go
@@ -20,8 +20,8 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager"
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 // Install registers the API group and adds types to a scheme

--- a/pkg/apis/certmanager/v1alpha1/doc.go
+++ b/pkg/apis/certmanager/v1alpha1/doc.go
@@ -1,5 +1,5 @@
 // +k8s:deepcopy-gen=package,register
-// +k8s:conversion-gen=github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager
+// +k8s:conversion-gen=github.com/jetstack/cert-manager/pkg/apis/certmanager
 // +k8s:openapi-gen=true
 // +k8s:defaulter-gen=TypeMeta
 

--- a/pkg/apis/certmanager/v1alpha1/register.go
+++ b/pkg/apis/certmanager/v1alpha1/register.go
@@ -14,7 +14,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/clientset.go
+++ b/pkg/client/clientset/versioned/clientset.go
@@ -17,7 +17,7 @@ package versioned
 
 import (
 	glog "github.com/golang/glog"
-	certmanagerv1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
+	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
 	discovery "k8s.io/client-go/discovery"
 	rest "k8s.io/client-go/rest"
 	flowcontrol "k8s.io/client-go/util/flowcontrol"

--- a/pkg/client/clientset/versioned/fake/clientset_generated.go
+++ b/pkg/client/clientset/versioned/fake/clientset_generated.go
@@ -16,9 +16,9 @@ limitations under the License.
 package fake
 
 import (
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	certmanagerv1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
-	fakecertmanagerv1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
+	fakecertmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/discovery"

--- a/pkg/client/clientset/versioned/fake/register.go
+++ b/pkg/client/clientset/versioned/fake/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	certmanagerv1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/scheme/register.go
+++ b/pkg/client/clientset/versioned/scheme/register.go
@@ -16,7 +16,7 @@ limitations under the License.
 package scheme
 
 import (
-	certmanagerv1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	certmanagerv1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/certificate.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/certificate.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	scheme "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	scheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/certmanager_client.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/certmanager_client.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
 	serializer "k8s.io/apimachinery/pkg/runtime/serializer"
 	rest "k8s.io/client-go/rest"
 )

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/clusterissuer.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/clusterissuer.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	scheme "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	scheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_certificate.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_certificate.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_certmanager_client.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_certmanager_client.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
 	rest "k8s.io/client-go/rest"
 	testing "k8s.io/client-go/testing"
 )

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_clusterissuer.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_clusterissuer.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_issuer.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/fake/fake_issuer.go
@@ -16,7 +16,7 @@ limitations under the License.
 package fake
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	labels "k8s.io/apimachinery/pkg/labels"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/issuer.go
+++ b/pkg/client/clientset/versioned/typed/certmanager/v1alpha1/issuer.go
@@ -16,8 +16,8 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	scheme "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/scheme"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	scheme "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/scheme"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	types "k8s.io/apimachinery/pkg/types"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/certmanager/interface.go
+++ b/pkg/client/informers/externalversions/certmanager/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package certmanager
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	internalinterfaces "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/pkg/client/informers/externalversions/certmanager/v1alpha1/certificate.go
+++ b/pkg/client/informers/externalversions/certmanager/v1alpha1/certificate.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	certmanager_v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	versioned "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	certmanager_v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	versioned "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/certmanager/v1alpha1/clusterissuer.go
+++ b/pkg/client/informers/externalversions/certmanager/v1alpha1/clusterissuer.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	certmanager_v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	versioned "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	certmanager_v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	versioned "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/certmanager/v1alpha1/interface.go
+++ b/pkg/client/informers/externalversions/certmanager/v1alpha1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/pkg/client/informers/externalversions/certmanager/v1alpha1/issuer.go
+++ b/pkg/client/informers/externalversions/certmanager/v1alpha1/issuer.go
@@ -19,10 +19,10 @@ limitations under the License.
 package v1alpha1
 
 import (
-	certmanager_v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	versioned "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	certmanager_v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	versioned "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	internalinterfaces "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	watch "k8s.io/apimachinery/pkg/watch"

--- a/pkg/client/informers/externalversions/factory.go
+++ b/pkg/client/informers/externalversions/factory.go
@@ -19,9 +19,9 @@ limitations under the License.
 package externalversions
 
 import (
-	versioned "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	certmanager "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/certmanager"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
+	versioned "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	certmanager "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager"
+	internalinterfaces "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/internalinterfaces"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/client/informers/externalversions/generic.go
+++ b/pkg/client/informers/externalversions/generic.go
@@ -20,7 +20,7 @@ package externalversions
 
 import (
 	"fmt"
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"
 	cache "k8s.io/client-go/tools/cache"
 )

--- a/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
+++ b/pkg/client/informers/externalversions/internalinterfaces/factory_interfaces.go
@@ -19,7 +19,7 @@ limitations under the License.
 package internalinterfaces
 
 import (
-	versioned "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
+	versioned "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	cache "k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/certmanager/v1alpha1/certificate.go
+++ b/pkg/client/listers/certmanager/v1alpha1/certificate.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/certmanager/v1alpha1/clusterissuer.go
+++ b/pkg/client/listers/certmanager/v1alpha1/clusterissuer.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/client/listers/certmanager/v1alpha1/issuer.go
+++ b/pkg/client/listers/certmanager/v1alpha1/issuer.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	v1alpha1 "github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	v1alpha1 "github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"

--- a/pkg/controller/certificates/checks.go
+++ b/pkg/controller/certificates/checks.go
@@ -7,7 +7,7 @@ import (
 	extv1beta1 "k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 func (c *Controller) certificatesForSecret(secret *corev1.Secret) ([]*v1alpha1.Certificate, error) {

--- a/pkg/controller/certificates/controller.go
+++ b/pkg/controller/certificates/controller.go
@@ -19,15 +19,15 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
-	cmlisters "github.com/jetstack-experimental/cert-manager/pkg/client/listers/certmanager/v1alpha1"
-	controllerpkg "github.com/jetstack-experimental/cert-manager/pkg/controller"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	"github.com/jetstack-experimental/cert-manager/pkg/scheduler"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
-	coreinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
-	extinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/extensions/v1beta1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	"github.com/jetstack/cert-manager/pkg/scheduler"
+	"github.com/jetstack/cert-manager/pkg/util"
+	coreinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
+	extinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/extensions/v1beta1"
 )
 
 type Controller struct {

--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -13,12 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/golang/glog"
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/errors"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 const renewBefore = time.Hour * 24 * 30

--- a/pkg/controller/clusterissuers/checks.go
+++ b/pkg/controller/clusterissuers/checks.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 func (c *Controller) issuersForSecret(secret *corev1.Secret) ([]*v1alpha1.ClusterIssuer, error) {

--- a/pkg/controller/clusterissuers/controller.go
+++ b/pkg/controller/clusterissuers/controller.go
@@ -17,13 +17,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
-	cmlisters "github.com/jetstack-experimental/cert-manager/pkg/client/listers/certmanager/v1alpha1"
-	controllerpkg "github.com/jetstack-experimental/cert-manager/pkg/controller"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
-	coreinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	"github.com/jetstack/cert-manager/pkg/util"
+	coreinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
 )
 
 type Controller struct {

--- a/pkg/controller/clusterissuers/sync.go
+++ b/pkg/controller/clusterissuers/sync.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 const (

--- a/pkg/controller/clusterissuers/sync_test.go
+++ b/pkg/controller/clusterissuers/sync_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
 )
 
 func newFakeIssuerWithStatus(name string, status v1alpha1.IssuerStatus) *v1alpha1.ClusterIssuer {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -4,10 +4,10 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	informers "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	kubeinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	informers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	kubeinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers"
 )
 
 // Context contains various types that are used by controller implementations.

--- a/pkg/controller/issuers/checks.go
+++ b/pkg/controller/issuers/checks.go
@@ -6,7 +6,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 func (c *Controller) issuersForSecret(secret *corev1.Secret) ([]*v1alpha1.Issuer, error) {

--- a/pkg/controller/issuers/controller.go
+++ b/pkg/controller/issuers/controller.go
@@ -17,13 +17,13 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	cminformers "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
-	cmlisters "github.com/jetstack-experimental/cert-manager/pkg/client/listers/certmanager/v1alpha1"
-	controllerpkg "github.com/jetstack-experimental/cert-manager/pkg/controller"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
-	coreinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	cminformers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions/certmanager/v1alpha1"
+	cmlisters "github.com/jetstack/cert-manager/pkg/client/listers/certmanager/v1alpha1"
+	controllerpkg "github.com/jetstack/cert-manager/pkg/controller"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	"github.com/jetstack/cert-manager/pkg/util"
+	coreinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
 )
 
 type Controller struct {

--- a/pkg/controller/issuers/sync.go
+++ b/pkg/controller/issuers/sync.go
@@ -7,7 +7,7 @@ import (
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 const (

--- a/pkg/controller/issuers/sync_test.go
+++ b/pkg/controller/issuers/sync_test.go
@@ -9,8 +9,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgotesting "k8s.io/client-go/testing"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/fake"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/client/clientset/versioned/fake"
 )
 
 func newFakeIssuerWithStatus(name string, status v1alpha1.IssuerStatus) *v1alpha1.Issuer {

--- a/pkg/issuer/acme/acme.go
+++ b/pkg/issuer/acme/acme.go
@@ -11,12 +11,12 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/http"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"github.com/jetstack/cert-manager/pkg/issuer"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/http"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
 )
 
 // Acme is an issuer for an ACME server. It can be used to register and obtain

--- a/pkg/issuer/acme/dns/clouddns/clouddns.go
+++ b/pkg/issuer/acme/dns/clouddns/clouddns.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/dns/v1"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/util"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 // DNSProvider is an implementation of the DNSProvider interface.

--- a/pkg/issuer/acme/dns/cloudflare/cloudflare.go
+++ b/pkg/issuer/acme/dns/cloudflare/cloudflare.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/util"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 // CloudFlareAPIURL represents the API endpoint to call.

--- a/pkg/issuer/acme/dns/dns.go
+++ b/pkg/issuer/acme/dns/dns.go
@@ -9,11 +9,11 @@ import (
 	"k8s.io/client-go/kubernetes"
 	corev1listers "k8s.io/client-go/listers/core/v1"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/clouddns"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/cloudflare"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/route53"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/clouddns"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/cloudflare"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/route53"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 const (

--- a/pkg/issuer/acme/dns/route53/route53.go
+++ b/pkg/issuer/acme/dns/route53/route53.go
@@ -16,7 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/route53"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/dns/util"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/dns/util"
 )
 
 const (

--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -23,10 +23,10 @@ import (
 	corev1listers "k8s.io/client-go/listers/core/v1"
 	"k8s.io/ingress/core/pkg/ingress/annotations/class"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer/acme/http/solver"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/issuer/acme/http/solver"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
 )
 
 const (

--- a/pkg/issuer/acme/issue.go
+++ b/pkg/issuer/acme/issue.go
@@ -11,10 +11,10 @@ import (
 	"github.com/golang/glog"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/errors"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 const (

--- a/pkg/issuer/acme/prepare.go
+++ b/pkg/issuer/acme/prepare.go
@@ -11,9 +11,9 @@ import (
 	"k8s.io/api/core/v1"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 const (

--- a/pkg/issuer/acme/prepare_test.go
+++ b/pkg/issuer/acme/prepare_test.go
@@ -1,0 +1,1 @@
+package acme

--- a/pkg/issuer/acme/renew.go
+++ b/pkg/issuer/acme/renew.go
@@ -3,7 +3,7 @@ package acme
 import (
 	"context"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 const (

--- a/pkg/issuer/acme/setup.go
+++ b/pkg/issuer/acme/setup.go
@@ -7,16 +7,16 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/golang/glog"
 	"golang.org/x/crypto/acme"
 	"k8s.io/api/core/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/golang/glog"
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/errors"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 const (

--- a/pkg/issuer/ca/ca.go
+++ b/pkg/issuer/ca/ca.go
@@ -5,9 +5,9 @@ import (
 	corelisters "k8s.io/client-go/listers/core/v1"
 	"k8s.io/client-go/tools/record"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	"github.com/jetstack-experimental/cert-manager/pkg/issuer"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"github.com/jetstack/cert-manager/pkg/issuer"
 )
 
 // CA is a simple CA implementation backed by the Kubernetes API server.

--- a/pkg/issuer/ca/issue.go
+++ b/pkg/issuer/ca/issue.go
@@ -11,11 +11,12 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/errors"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 const (

--- a/pkg/issuer/ca/prepare.go
+++ b/pkg/issuer/ca/prepare.go
@@ -3,7 +3,7 @@ package ca
 import (
 	"context"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 // Prepare does nothing for the CA issuer. In future, this may validate

--- a/pkg/issuer/ca/renew.go
+++ b/pkg/issuer/ca/renew.go
@@ -3,9 +3,9 @@ package ca
 import (
 	"context"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 )
 
 const (

--- a/pkg/issuer/ca/setup.go
+++ b/pkg/issuer/ca/setup.go
@@ -7,8 +7,8 @@ import (
 	"k8s.io/api/core/v1"
 
 	"github.com/golang/glog"
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/kube"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util/kube"
 )
 
 const (

--- a/pkg/issuer/const.go
+++ b/pkg/issuer/const.go
@@ -3,7 +3,7 @@ package issuer
 import (
 	"fmt"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 const (

--- a/pkg/issuer/context.go
+++ b/pkg/issuer/context.go
@@ -4,9 +4,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/record"
 
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	informers "github.com/jetstack-experimental/cert-manager/pkg/client/informers/externalversions"
-	kubeinformers "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	informers "github.com/jetstack/cert-manager/pkg/client/informers/externalversions"
+	kubeinformers "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers"
 )
 
 // Context contains various types that are used by Issuer implementations.

--- a/pkg/issuer/factory.go
+++ b/pkg/issuer/factory.go
@@ -3,7 +3,7 @@ package issuer
 import (
 	"fmt"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 // Factory is an interface that can be used to obtain Issuer implementations.

--- a/pkg/issuer/issuer.go
+++ b/pkg/issuer/issuer.go
@@ -3,7 +3,7 @@ package issuer
 import (
 	"context"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 type Interface interface {

--- a/pkg/issuer/register.go
+++ b/pkg/issuer/register.go
@@ -3,7 +3,7 @@ package issuer
 import (
 	"sync"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 // Constructor constructs an issuer given an Issuer resource and a Context.

--- a/pkg/util/kube/pki.go
+++ b/pkg/util/kube/pki.go
@@ -4,8 +4,8 @@ import (
 	"crypto/rsa"
 	"crypto/x509"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/util/errors"
-	"github.com/jetstack-experimental/cert-manager/pkg/util/pki"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/pki"
 	api "k8s.io/api/core/v1"
 	corelisters "k8s.io/client-go/listers/core/v1"
 )

--- a/pkg/util/pki/csr.go
+++ b/pkg/util/pki/csr.go
@@ -3,7 +3,7 @@ package pki
 import (
 	"crypto/x509"
 	"crypto/x509/pkix"
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
 )
 
 // The provided Certificate *must* specify either a DNS name or a

--- a/pkg/util/pki/parse.go
+++ b/pkg/util/pki/parse.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/util/errors"
+	"github.com/jetstack/cert-manager/pkg/util/errors"
 )
 
 func DecodePKCS1PrivateKeyBytes(keyBytes []byte) (*rsa.PrivateKey, error) {

--- a/test/e2e/certificate/certificate_acme.go
+++ b/test/e2e/certificate/certificate_acme.go
@@ -24,10 +24,10 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	cmutil "github.com/jetstack-experimental/cert-manager/pkg/util"
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
-	"github.com/jetstack-experimental/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	cmutil "github.com/jetstack/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/util"
 )
 
 const testingACMEURL = "http://127.0.0.1:4000/directory"

--- a/test/e2e/certificate/certificate_ca.go
+++ b/test/e2e/certificate/certificate_ca.go
@@ -19,9 +19,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
-	"github.com/jetstack-experimental/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/util"
 )
 
 var _ = framework.CertManagerDescribe("CA Certificate", func() {

--- a/test/e2e/clusterissuer/clusterissuer_ca.go
+++ b/test/e2e/clusterissuer/clusterissuer_ca.go
@@ -17,9 +17,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
-	"github.com/jetstack-experimental/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/util"
 )
 
 var _ = framework.CertManagerDescribe("CA ClusterIssuer", func() {

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -22,11 +22,11 @@ import (
 	"github.com/onsi/gomega"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/logs"
-	_ "github.com/jetstack-experimental/cert-manager/test/e2e/certificate"
-	_ "github.com/jetstack-experimental/cert-manager/test/e2e/clusterissuer"
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
-	_ "github.com/jetstack-experimental/cert-manager/test/e2e/issuer"
+	"github.com/jetstack/cert-manager/pkg/logs"
+	_ "github.com/jetstack/cert-manager/test/e2e/certificate"
+	_ "github.com/jetstack/cert-manager/test/e2e/clusterissuer"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	_ "github.com/jetstack/cert-manager/test/e2e/issuer"
 )
 
 // TestE2E checks configuration parameters (specified through flags) and then runs

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/golang/glog"
 	"k8s.io/client-go/tools/clientcmd"
 
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
 )
 
 func init() {

--- a/test/e2e/framework/framework.go
+++ b/test/e2e/framework/framework.go
@@ -22,8 +22,8 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned"
-	"github.com/jetstack-experimental/cert-manager/test/util"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned"
+	"github.com/jetstack/cert-manager/test/util"
 )
 
 const (

--- a/test/e2e/issuer/issuer_acme.go
+++ b/test/e2e/issuer/issuer_acme.go
@@ -22,9 +22,9 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
-	"github.com/jetstack-experimental/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/util"
 )
 
 var _ = framework.CertManagerDescribe("ACME Issuer", func() {

--- a/test/e2e/issuer/issuer_ca.go
+++ b/test/e2e/issuer/issuer_ca.go
@@ -17,9 +17,9 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/test/e2e/framework"
-	"github.com/jetstack-experimental/cert-manager/test/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/test/e2e/framework"
+	"github.com/jetstack/cert-manager/test/util"
 )
 
 var _ = framework.CertManagerDescribe("CA Issuer", func() {

--- a/test/manifests/acme-http-cert-2.yaml
+++ b/test/manifests/acme-http-cert-2.yaml
@@ -1,0 +1,18 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: acme-http-cert-2
+  namespace: "default"
+spec:
+  acme:
+    config:
+    - http01:
+        ingressClass: nginx
+      domains:
+      - acme-http-2.k8s.school
+      - acme-cn-2.k8s.school
+  commonName: acme-http-2.k8s.school
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-staging
+  secretName: acme-http-k8s-school-2

--- a/test/manifests/acme-http-cert.yaml
+++ b/test/manifests/acme-http-cert.yaml
@@ -1,0 +1,20 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: Certificate
+metadata:
+  name: acme-http-cert
+  namespace: "default"
+spec:
+  acme:
+    config:
+    - http01:
+        ingressClass: nginx
+      domains:
+      - acme-http.k8s.school
+      - acme-cn.k8s.school
+  commonName: acme-cn.k8s.school
+  dnsNames:
+  - acme-http.k8s.school
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-staging
+  secretName: acme-http-k8s-school

--- a/test/manifests/acme-prod-clusterissuer.yaml
+++ b/test/manifests/acme-prod-clusterissuer.yaml
@@ -1,0 +1,12 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-prod
+spec:
+  acme:
+    email: james@jetstack.io
+    privateKeySecretRef:
+      key: "priv.key"
+      name: letsencrypt-prod
+    server: https://acme-v01.api.letsencrypt.org/directory
+    http01: {}

--- a/test/manifests/acme-staging-clusterissuer.yaml
+++ b/test/manifests/acme-staging-clusterissuer.yaml
@@ -1,0 +1,12 @@
+apiVersion: certmanager.k8s.io/v1alpha1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging
+spec:
+  acme:
+    email: james@jetstack.io
+    privateKeySecretRef:
+      key: "priv.key"
+      name: letsencrypt-staging
+    server: https://acme-staging.api.letsencrypt.org/directory
+    http01: {}

--- a/test/util/util.go
+++ b/test/util/util.go
@@ -13,16 +13,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"crypto/x509"
-	"github.com/jetstack-experimental/cert-manager/pkg/apis/certmanager/v1alpha1"
-	clientset "github.com/jetstack-experimental/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
-	"github.com/jetstack-experimental/cert-manager/pkg/util"
+	"github.com/jetstack/cert-manager/pkg/apis/certmanager/v1alpha1"
+	clientset "github.com/jetstack/cert-manager/pkg/client/clientset/versioned/typed/certmanager/v1alpha1"
+	"github.com/jetstack/cert-manager/pkg/util"
 )
 
 var certManagerImageFlag string
 var certManagerImagePullPolicy string
 
 func init() {
-	flag.StringVar(&certManagerImageFlag, "cert-manager-image", "jetstackexperimental/cert-manager-controller:canary",
+	flag.StringVar(&certManagerImageFlag, "cert-manager-image", "quay.io/jetstack/cert-manager-controller:canary",
 		"The container image for cert-manager to test against")
 	flag.StringVar(&certManagerImagePullPolicy, "cert-manager-image-pull-policy", "Never",
 		"The image pull policy to use for cert-manager when running tests")

--- a/third_party/k8s.io/client-go/informers/core/interface.go
+++ b/third_party/k8s.io/client-go/informers/core/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package core
 
 import (
-	v1 "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	v1 "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/core/v1"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/third_party/k8s.io/client-go/informers/core/v1/componentstatus.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/componentstatus.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/configmap.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/configmap.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/endpoints.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/endpoints.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/event.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/event.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/interface.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/third_party/k8s.io/client-go/informers/core/v1/limitrange.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/limitrange.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/namespace.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/namespace.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/node.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/node.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/persistentvolume.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/persistentvolume.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/persistentvolumeclaim.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/pod.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/pod.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/podtemplate.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/podtemplate.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/replicationcontroller.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/replicationcontroller.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/resourcequota.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/resourcequota.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/secret.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/secret.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/service.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/service.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/core/v1/serviceaccount.go
+++ b/third_party/k8s.io/client-go/informers/core/v1/serviceaccount.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	core_v1 "k8s.io/api/core/v1"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/extensions/interface.go
+++ b/third_party/k8s.io/client-go/informers/extensions/interface.go
@@ -19,8 +19,8 @@ limitations under the License.
 package extensions
 
 import (
-	v1beta1 "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/extensions/v1beta1"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	v1beta1 "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/extensions/v1beta1"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 )
 
 // Interface provides access to each of this group's versions.

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/daemonset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/deployment.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/ingress.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/interface.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/interface.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 )
 
 // Interface provides access to all the informers in this group version.

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/podsecuritypolicy.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/podsecuritypolicy.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/replicaset.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/extensions/v1beta1/thirdpartyresource.go
+++ b/third_party/k8s.io/client-go/informers/extensions/v1beta1/thirdpartyresource.go
@@ -19,7 +19,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	extensions_v1beta1 "k8s.io/api/extensions/v1beta1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"

--- a/third_party/k8s.io/client-go/informers/factory.go
+++ b/third_party/k8s.io/client-go/informers/factory.go
@@ -19,9 +19,9 @@ limitations under the License.
 package informers
 
 import (
-	core "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/core"
-	extensions "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/extensions"
-	internalinterfaces "github.com/jetstack-experimental/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
+	core "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/core"
+	extensions "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/extensions"
+	internalinterfaces "github.com/jetstack/cert-manager/third_party/k8s.io/client-go/informers/internalinterfaces"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	schema "k8s.io/apimachinery/pkg/runtime/schema"


### PR DESCRIPTION
**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Closes #134 

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Move to 'jetstack' organisation.

Action required: this will require updating your existing deployments to point to the new image repository, as new tags will not be pushed to the old 'jetstackexperimental/cert-manager-controller` repository.
```

/area admin
/assign
/release-note-action-required