### PR TITLE
Error if existing presented key and expected key do not match

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -465,9 +465,7 @@ func testReachability(ctx context.Context, domain, path, key string) error {
 	}
 
 	if string(presentedKey) != key {
-		if err != nil {
-			return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey, key)
-		}
+		return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey, key)
 	}
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/devel/pull-requests.md#the-pr-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/devel/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/devel/pull-requests.md#write-release-notes-if-needed
-->

**What this PR does / why we need it**:

A type in the HTTP01 solver caused it to not return an error if the key presented by the ingress and the expected key do not match.

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #163 

**Special notes for your reviewer**:

**Release note**:
<!--  Steps to write your release note:
1. Use the release-note-* labels to set the release note state (if you have access)
2. Enter your extended release note in the below block; leaving it blank means using the PR title as the release note. If no release note is required, just write `NONE`.
-->
```release-note
Fix bug in ACME HTTP01 solver causing self-check to return true before paths have propagated
```
