### PR TITLE
Automated cherry pick of #166

### DIFF
--- a/pkg/issuer/acme/http/http.go
+++ b/pkg/issuer/acme/http/http.go
@@ -465,9 +465,7 @@ func testReachability(ctx context.Context, domain, path, key string) error {
 	}
 
 	if string(presentedKey) != key {
-		if err != nil {
-			return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey, key)
-		}
+		return fmt.Errorf("presented key (%s) did not match expected (%s)", presentedKey, key)
 	}
 
 	return nil


### PR DESCRIPTION
Cherry pick of #166 on release-0.1.

#166: Error if existing presented key and expected key do not match