### PR TITLE
Set TLS certificate secret type to TLS type

### DIFF
--- a/pkg/controller/certificates/sync.go
+++ b/pkg/controller/certificates/sync.go
@@ -224,6 +224,7 @@ func (c *Controller) issue(ctx context.Context, issuer issuer.Interface, crt *v1
 			Name:      crt.Spec.SecretName,
 			Namespace: crt.Namespace,
 		},
+		Type: api.SecretTypeTLS,
 		Data: map[string][]byte{
 			api.TLSCertKey:       cert,
 			api.TLSPrivateKeyKey: key,
@@ -279,6 +280,7 @@ func (c *Controller) renew(ctx context.Context, issuer issuer.Interface, crt *v1
 			Name:      crt.Spec.SecretName,
 			Namespace: crt.Namespace,
 		},
+		Type: api.SecretTypeTLS,
 		Data: map[string][]byte{
 			api.TLSCertKey:       cert,
 			api.TLSPrivateKeyKey: key,


### PR DESCRIPTION
**What this PR does / why we need it**:

Set the Kubernetes secret type to TLS

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

Fixes #133 

**Release note**:
```release-note
Set the Kubernetes secret type to TLS.
Action required: this will cause renewals of existing certificates to fail. You **must** delete certificates that have been previously produced by cert-manager else cert-manager may enter a renewal loop when saving the new certificates. Alternatively, you may specify a new secret to store your certificate in and manually update your ingress resource/applications reference the secret.
```
